### PR TITLE
为入群欢迎增加了插入群名称，用户昵称，用户头像的功能，修改kotlin版本为1.8.0，修改mirai-console版本为2.14.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
-    val kotlinVersion = "1.6.10"
+    val kotlinVersion = "1.8.0"
     kotlin("jvm") version kotlinVersion
     kotlin("plugin.serialization") version kotlinVersion
 
-    id("net.mamoe.mirai-console") version "2.10.1"
+    id("net.mamoe.mirai-console") version "2.14.0"
 }
 
 group = "top.colter"

--- a/src/main/kotlin/top/colter/mirai/plugin/welcome/PluginMain.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/welcome/PluginMain.kt
@@ -1,6 +1,8 @@
 package top.colter.mirai.plugin.welcome
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import net.mamoe.mirai.console.command.CommandManager.INSTANCE.register
 import net.mamoe.mirai.console.command.CommandManager.INSTANCE.unregister
 import net.mamoe.mirai.console.permission.PermissionId
@@ -13,12 +15,15 @@ import net.mamoe.mirai.contact.Friend
 import net.mamoe.mirai.event.*
 import net.mamoe.mirai.event.events.*
 import net.mamoe.mirai.message.data.*
+import net.mamoe.mirai.utils.ExternalResource.Companion.uploadAsImage
 import net.mamoe.mirai.utils.MiraiExperimentalApi
 import net.mamoe.mirai.utils.info
 import top.colter.mirai.plugin.welcome.WelcomePluginConfig.botInvitedJoinGroupRequest
 import top.colter.mirai.plugin.welcome.WelcomePluginConfig.friendWelcomeMessage
 import top.colter.mirai.plugin.welcome.WelcomePluginConfig.groupWelcomeMessage
 import top.colter.mirai.plugin.welcome.WelcomePluginConfig.newFriendRequest
+import java.io.InputStream
+import java.net.URL
 
 object PluginMain : KotlinPlugin(
     JvmPluginDescription(
@@ -56,9 +61,42 @@ object PluginMain : KotlinPlugin(
         }
 
         eventChannel.subscribeAlways<MemberJoinEvent> {
+
+            val groupName = it.group.name
+            val userName = it.user.nick
+            val userAvatarUrl = it.user.avatarUrl//获取基础信息，如群名，用户名，用户头像url
+
+            var message = groupWelcomeMessage
+            message = message.replace("${'$'}{群名}",groupName)
+                .replace("${'$'}{用户名}",userName)//替换非图像类的用户信息
+
+            val userAvatarUrlInputStream : InputStream =
+                withContext(Dispatchers.IO) {
+                    URL(userAvatarUrl).openStream()
+                }
+            logger.info { "userAvatarUrl:${userAvatarUrl}" }
+            val userAvatarImage :Image
+            userAvatarUrlInputStream.use {
+                userAvatarImage = userAvatarUrlInputStream.uploadAsImage(group)
+            }//获取用户头像，生成Image对象
+
             val hasPerm = group.permitteeId.getPermittedPermissions().any { it.id == gwp }
-            if (hasPerm && groupWelcomeMessage.isNotEmpty()) {
-                group.sendMessage(At(user) + " " + groupWelcomeMessage)
+            if (hasPerm && message.isNotEmpty()) {
+                val messageSendListData =  message.split("${'$'}{头像}")
+                var messageSend : Message = At(user)
+
+                if (messageSendListData.size == 1){//判断是否需要替换头像，如list长度为一，则不需要替换头像
+                    messageSend += messageSendListData[0]
+
+                }else if (messageSendListData.size >= 2){
+                    val iterator = messageSendListData.iterator()
+                    messageSend += iterator.next()
+                    while (iterator.hasNext()){
+                        messageSend += userAvatarImage
+                        messageSend += iterator.next()
+                    }
+                }
+                group.sendMessage(messageSend)
             }
         }
 

--- a/src/main/kotlin/top/colter/mirai/plugin/welcome/WelcomePluginConfig.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/welcome/WelcomePluginConfig.kt
@@ -18,8 +18,8 @@ object WelcomePluginConfig: ReadOnlyPluginConfig("WelcomePluginConfig"){
     @ValueDescription("好友请求欢迎语\n如不需要请填写 '' 两个单引号")
     val friendWelcomeMessage: String by value("( •̀ ω •́ )✧")
 
-    @ValueDescription("新成员加群欢迎语(需要授权)\n如不需要请填写 '' 两个单引号")
-    val groupWelcomeMessage: String by value("欢迎( •̀ ω •́ )✧")
+    @ValueDescription("新成员加群欢迎语(需要授权)\n如不需要请填写 '' 两个单引号\n${'$'}{群名}替换被加群的群名，${'$'}{用户名}替换新加群员的昵称，${'$'}{头像}替换新加群员的头像\n注：暂时不支持取消关键词替换")
+    val groupWelcomeMessage: String by value("${'$'}{用户名}，欢迎入群( •̀ ω •́ )✧")
 
 
 }


### PR DESCRIPTION
经真实环境验证，该功能正常。
验证环境：
使用https://github.com/iTXTech/mirai-console-loader/releases/download/v2.1.2/mcl-2.1.2.zip
同时使用eclipse-temurin:17打包的docker镜像
（本人开发经验不足，kotlin经验也不足，如果新增代码有bug我提前谢罪）

功能说明：对于入群欢迎功能，在WelcomePluginConfig.yml配置文件中，修改配置项groupWelcomeMessage:的文本，当文本中有${用户名}，${头像}，${群名}时，分别会被替换成实际的用户名，头像，群名